### PR TITLE
Overwrite Displayname use also Company and Emailaddress

### DIFF
--- a/content/provider/eas/contactsync.js
+++ b/content/provider/eas/contactsync.js
@@ -318,8 +318,12 @@ var contactsync = {
                                             modcard.setProperty("PhotoURI", filePath);
                                             photo = '';
                                         }
-                                        if (tbSync.db.getAccountSetting(eas.syncdata.account, "displayoverride") == "1") {
-                                            modcard.setProperty("DisplayName", modcard.getProperty("FirstName", "") + " " + modcard.getProperty("LastName", ""));
+
+                                        if (tbSync.db.getAccountSetting(eas.syncdata.account, "displayoverride") == "1" ) {
+                                          modcard.setProperty("DisplayName", modcard.getProperty("FirstName", "") + " " + modcard.getProperty("LastName", ""));
+
+                                          if (modcard.getProperty("DisplayName", "" ) == " " )
+                                            modcard.setProperty("DisplayName", card.getProperty("Company", card.getProperty("PrimaryEmail", "")));
                                         }
 
                                         /* newCard = */ addressBook.modifyCard(modcard);
@@ -381,6 +385,9 @@ var contactsync = {
                                 }
                                 if (tbSync.db.getAccountSetting(eas.syncdata.account, "displayoverride") == "1") {
                                     modcard.setProperty("DisplayName", modcard.getProperty("FirstName", "") + " " + modcard.getProperty("LastName", ""));
+
+                                    if (modcard.getProperty("DisplayName", "" ) == " " )
+                                        modcard.setProperty("DisplayName", card.getProperty("Company", card.getProperty("PrimaryEmail", "")));
                                 }
                                 /* newCard = */ addressBook.modifyCard(modcard);
 

--- a/content/tbsync.jsm
+++ b/content/tbsync.jsm
@@ -16,6 +16,8 @@ Components.utils.import("resource://gre/modules/FileUtils.jsm");
 Components.utils.import("resource://gre/modules/osfile.jsm");
 Components.utils.import("resource://gre/modules/Task.jsm");
 
+Components.utils.import("resource://gre/modules/Console.jsm");
+
 
 /* TODO
  - explizitly use if (error !== "") not if (error) - fails on "0"
@@ -496,7 +498,10 @@ var tbSync = {
 
     addNewCardFromServer: function (card, addressBook, account) {
         if (tbSync.db.getAccountSetting(account, "displayoverride") == "1") {
-            card.setProperty("DisplayName", card.getProperty("FirstName", "") + " " + card.getProperty("LastName", ""));
+           card.setProperty("DisplayName", card.getProperty("FirstName", "") + " " + card.getProperty("LastName", ""));
+
+        if (card.getProperty("DisplayName", "" ) == " " )
+           card.setProperty("DisplayName", card.getProperty("Company", card.getProperty("PrimaryEmail", "")));
         }
         
         //Remove the ServerID from the card, add the card without serverId and modify the added card later on - otherwise the ServerId will be removed by the onAddItem-listener

--- a/content/tbsync.jsm
+++ b/content/tbsync.jsm
@@ -16,8 +16,6 @@ Components.utils.import("resource://gre/modules/FileUtils.jsm");
 Components.utils.import("resource://gre/modules/osfile.jsm");
 Components.utils.import("resource://gre/modules/Task.jsm");
 
-Components.utils.import("resource://gre/modules/Console.jsm");
-
 
 /* TODO
  - explizitly use if (error !== "") not if (error) - fails on "0"

--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
     <Description about="urn:mozilla:install-manifest">
         <em:id>tbsync@jobisoft.de</em:id>
         <em:name>TbSync (Provider for Exchange ActiveSync)</em:name>
-        <em:version>0.6.8</em:version>
+        <em:version>0.6.8-19</em:version>
         <em:description>Synchronize Exchange ActiveSync accounts to Thunderbird Addressbook and Calendar</em:description>
         <em:creator>John Bieling</em:creator>
         <em:homepageURL>https://github.com/jobisoft/TbSync</em:homepageURL>


### PR DESCRIPTION
If you use the option "overwrite displayname" the company resp. the emailaddress will be use if the name is empty. 