### PR TITLE
Recurring Events

### DIFF
--- a/content/provider/eas/calendarsync.js
+++ b/content/provider/eas/calendarsync.js
@@ -485,6 +485,11 @@ eas.calendarsync = {
                     for (let i = 0; i < 7; ++i) {
                         if (DOW & 1 << i) days.push(i + 1);
                     }
+                    if (data.Recurrence.WeekOfMonth) {
+                        for (let i = 0; i < days.length; ++i) {
+                            days[i] += 8 * ((data.Recurrence.WeekOfMonth != 5) ? (data.Recurrence.WeekOfMonth - 0) : -1);
+                        }
+                    }
                     recRule.setComponent("BYDAY", days.length, days);
                 }
             }
@@ -505,9 +510,6 @@ eas.calendarsync = {
             }
             if (data.Recurrence.Until) {
                 recRule.untilDate = cal.createDateTime(data.Recurrence.Until);
-            }
-            if (data.Recurrence.WeekOfMonth) {
-                recRule.setComponent("BYWEEKNO", 1, [data.Recurrence.WeekOfMonth]);
             }
             item.recurrenceInfo.insertRecurrenceItemAt(recRule, 0);
         }

--- a/content/provider/eas/calendarsync.js
+++ b/content/provider/eas/calendarsync.js
@@ -659,8 +659,16 @@ eas.calendarsync = {
                         weeks[i] = Math.floor(weekDays[i] / 8);
                         weekDays[i] = weekDays[i] % 8;
                     }
+                    else if (weekDays[i] < -8) {
+                        // EAS only supports last week as a special value, treat
+                        // all as last week or assume every month has 5 weeks?
+                        // Change to last week
+                        //weeks[i] = 5;
+                        // Assumes 5 weeks per month for week <= -2
+                        weeks[i] = 6 - Math.floor(-weekDays[i] / 8);
+                        weekDays[i] = -weekDays[i] % 8;
+                    }
                 }
-                // TODO: negative week days eg -1MO
                 if (monthDays[0] && monthDays[0] == -1) {
                     weeks = [5];
                     weekDays = [1, 2, 3, 4, 5, 6, 7]; // 127

--- a/content/provider/eas/calendarsync.js
+++ b/content/provider/eas/calendarsync.js
@@ -469,14 +469,16 @@ eas.calendarsync = {
                 recRule.type = "YEARLY";
                 break;
             }
-            recRule.interval = data.Recurrence.Interval;
-            if (data.Recurrence.Until) {
-                recRule.untilDate = cal.createDateTime(data.Recurrence.Until);
+            if (data.Recurrence.CalendarType) {
+                // TODO
+            }
+            if (data.Recurrence.DayOfMonth) {
+                recRule.setComponent("BYMONTHDAY", 1, [data.Recurrence.DayOfMonth]);
             }
             if (data.Recurrence.DayOfWeek) {
                 let DOW = data.Recurrence.DayOfWeek;
                 if (DOW == 127) {
-                    // TODO: last day of month
+                    recRule.setComponent("BYMONTHDAY", 1, [-1]);
                 }
                 else {
                     let days = [];
@@ -486,17 +488,32 @@ eas.calendarsync = {
                     recRule.setComponent("BYDAY", days.length, days);
                 }
             }
+            if (data.Recurrence.FirstDayOfWeek) {
+                recRule.setComponent("WKST", 1, [data.Recurrence.FirstDayOfWeek]);
+            }
+            if (data.Recurrence.Interval) {
+                recRule.interval = data.Recurrence.Interval;
+            }
+            if (data.Recurrence.IsLeapMonth) {
+                // TODO
+            }
+            if (data.Recurrence.MonthOfYear) {
+                recRule.setComponent("BYMONTH", 1, [data.Recurrence.MonthOfYear]);
+            }
+            if (data.Recurrence.Occurrences) {
+                recRule.count = data.Recurrence.Occurrences;
+            }
+            if (data.Recurrence.Until) {
+                recRule.untilDate = cal.createDateTime(data.Recurrence.Until);
+            }
+            if (data.Recurrence.WeekOfMonth) {
+                recRule.setComponent("BYWEEKNO", 1, [data.Recurrence.WeekOfMonth]);
+            }
             item.recurrenceInfo.insertRecurrenceItemAt(recRule, 0);
         }
 
-        /* Missing : MeetingStatus, Attachements (needs EAS 16.0 !), Repeated Events
+        /* Missing : MeetingStatus, Attachements (needs EAS 16.0 !)
 
-            <Recurrence xmlns='Calendar'>
-                <Type xmlns='Calendar'>5</Type>
-                <Interval xmlns='Calendar'>1</Interval>
-                <DayOfMonth xmlns='Calendar'>15</DayOfMonth>
-                <MonthOfYear xmlns='Calendar'>11</MonthOfYear>
-            </Recurrence>
             <MeetingStatus xmlns='Calendar'>0</MeetingStatus>
             */
 

--- a/content/provider/eas/calendarsync.js
+++ b/content/provider/eas/calendarsync.js
@@ -449,6 +449,46 @@ eas.calendarsync = {
             item.organizer = organizer;
         }
 
+        if (data.Recurrence) {
+            item.recurrenceInfo = cal.createRecurrenceInfo();
+            item.recurrenceInfo.item = item;
+            let recRule = cal.createRecurrenceRule();
+            switch (data.Recurrence.Type) {
+            case "0":
+                recRule.type = "DAILY";
+                break;
+            case "1":
+                recRule.type = "WEEKLY";
+                break;
+            case "2":
+            case "3":
+                recRule.type = "MONTHLY";
+                break;
+            case "5":
+            case "6":
+                recRule.type = "YEARLY";
+                break;
+            }
+            recRule.interval = data.Recurrence.Interval;
+            if (data.Recurrence.Until) {
+                recRule.untilDate = cal.createDateTime(data.Recurrence.Until);
+            }
+            if (data.Recurrence.DayOfWeek) {
+                let DOW = data.Recurrence.DayOfWeek;
+                if (DOW == 127) {
+                    // TODO: last day of month
+                }
+                else {
+                    let days = [];
+                    for (let i = 0; i < 7; ++i) {
+                        if (DOW & 1 << i) days.push(i + 1);
+                    }
+                    recRule.setComponent("BYDAY", days.length, days);
+                }
+            }
+            item.recurrenceInfo.insertRecurrenceItemAt(recRule, 0);
+        }
+
         /* Missing : MeetingStatus, Attachements (needs EAS 16.0 !), Repeated Events
 
             <Recurrence xmlns='Calendar'>


### PR DESCRIPTION
I was unable to push recurrences on multiple days of the month. The documentation seems to suggest that multiple Recurrence tags could work as long as they don't overlap, but when I tried that the sync failed with an invalid item. [(Request XML)](https://github.com/jobisoft/TbSync/files/1608250/MultipleRecurrence.txt) I also couldn't create such an event from the online Outlook, so I'm unsure if it supports them at all. Maybe the desktop app is different, but I don't have access to that.

I also left out support for non-default calendar types because it seemed like far too much of a hassle for the benefit. IsLeapMonth is also not needed or useful with the Gregorian calendar and has been left out.

Edit: Noticed that pulling nth-week events don't work.
Edit: Fixed
  
  