### PR TITLE
Javascript error on eas sync after contact removed locally

### DIFF
--- a/content/provider/eas/contactsync.js
+++ b/content/provider/eas/contactsync.js
@@ -853,7 +853,7 @@ eas.contactsync = {
             // Send will send a request to the server, a responce will trigger callback, which will call senddel again.
             syncdata.cardstodelete = cardstodelete;
             
-            responseWbxml = yield eas.sendRequest(wbxml, "Sync", syncdata);
+            let responseWbxml = yield eas.sendRequest(wbxml, "Sync", syncdata);
 
             let firstcmd = responseWbxml.indexOf(String.fromCharCode(0x01, 0x46));
 


### PR DESCRIPTION
When you have deleted a contact locally the sync fails with an javascript error in senddel.