### PR TITLE
Add simple automatic sync feature

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@
 * John Bieling
 * Jan Dagefoerde
 * Nam Ldmpub
-
+* Fonic
 
 ## Translators
 * John Bieling (de, en-US)

--- a/content/modules/public.js
+++ b/content/modules/public.js
@@ -401,8 +401,12 @@ var FolderData = class {
       status = TbSync.getString("status." + this.getFolderProperty("status"), this.accountData.getAccountProperty("provider")).split("||")[0];
 
       switch (this.getFolderProperty("status").split(".")[0]) { //the status may have a sub-decleration
-        case "success":
         case "modified":
+          //trigger periodic sync (TbSync.syncTimer, tbsync.jsm)
+          if (!this.isSyncing()) {
+            this.accountData.setAccountProperty("lastsynctime", 0);
+          }
+        case "success":
           try {
             status = status + ": " + this.targetData.targetName;
           } catch (e) {


### PR DESCRIPTION
**This adds a simple automatic sync feature:**

If a folder is found to be modified, the `lastsynctime` property of the corresponding account is set to 0 to trigger periodic syncing. As the timer used for periodic syncing is set to run every 60s, this results in a sync being performed within the next minute after a change occurred. If periodic syncing is disabled (i.e. interval is set to 0), automatic syncing is disabled as well (which I think is a nice side effect).

Addresses issue #407.