### PR TITLE
Fixed wrong type check, which prevented checkboxes from being unchecked.

### DIFF
--- a/content/manager/editAccount.js
+++ b/content/manager/editAccount.js
@@ -347,7 +347,10 @@ var tbSyncAccountSettings = {
     let setting = field.id.replace("tbsync.accountsettings.pref.","");
     let value = "";
     
+/*
     if (field.tagName == "checkbox") {
+*/
+    if ((field.tagName == "checkbox") || ((field.tagName == "input") && (null != field.type) && (field.type == "checkbox"))) {
       if (field.checked) value = true;
       else value = false;
     } else {


### PR DESCRIPTION
Because we now use `<input type="checkbox">` instead of `<checkbox>`, this fix is mandatory; otherwise unchecked checkboxes will simply not save their "false" value.