### PR TITLE
chore: update strict max version to `139.*`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 * Jan Dagefoerde
 * Nam Ldmpub
 * Fonic
+* OOChaotic
 
 ## Translators
 * John Bieling (de, en-US)

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
     "gecko": {
       "id": "tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "138.*"
+      "strict_max_version": "139.*"
     }
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.15",
+  "version": "4.16",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",


### PR DESCRIPTION
Thunderbird `139.0` was released a month ago. This extension specifies a strict max version of `138.*`, which prevents users on `139.*` from installing it by making it inaccessible on the Thunderbird Add-ons site.

The update does not seem to interfere with the function of this extension, so this commit simply updates the max version to `139.*` to ensure users can install it on the latest Thunderbird version.

Fixes jobisoft/TbSync#748 