### PR TITLE
Fix compatibility with Thunderbird 143–147

### DIFF
--- a/content/manager/accounts.js
+++ b/content/manager/accounts.js
@@ -442,13 +442,13 @@ var tbSyncAccounts = {
     if (isInstalled) {
       entry.setAttribute("label",  TbSync.providers[provider].Base.getProviderName());
       entry.setAttribute("image", TbSync.providers[provider].Base.getProviderIcon(16));
-      entry.setAttribute("hidden", false);
+      entry.removeAttribute("hidden");
     } else if (isDefault) {
       entry.setAttribute("label", TbSync.providers.defaultProviders[provider].name);
       entry.setAttribute("image", "chrome://tbsync/content/skin/provider16.png");                    
-      entry.setAttribute("hidden", false);
+      entry.removeAttribute("hidden");
     } else {
-      entry.setAttribute("hidden", true);
+      entry.setAttribute("hidden", "true");
     }
   },
 

--- a/content/skin/ab.css
+++ b/content/skin/ab.css
@@ -4,5 +4,7 @@ treechildren::-moz-tree-image(DirCol, orphaned) {
 }
 
 .abMenuItem[AddrBook="true"][TbSyncIcon="orphaned"] {
+  /* TB143+ uses --menuitem-icon instead of list-style-image for menuitems */
+  --menuitem-icon: url("chrome://tbsync/content/skin/error16.png");
   list-style-image: url("chrome://tbsync/content/skin/error16.png");
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "gecko": {
       "id": "tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "146.*"
+      "strict_max_version": "150.*"
     }
   },
   "manifest_version": 2,

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "gecko": {
       "id": "tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "150.*"
+      "strict_max_version": "147.*"
     }
   },
   "manifest_version": 2,

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
     "gecko": {
       "id": "tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "146.*"
     }
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16",
+  "version": "4.16.1",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",


### PR DESCRIPTION
## Summary

- Fix `hidden` attribute handling for Thunderbird 143+: use `removeAttribute("hidden")` instead of `setAttribute("hidden", false)`, which sets the attribute to the string `"false"` and doesn't actually unhide the element
- Add `--menuitem-icon` CSS custom property for TB143+ menu icon rendering (TB switched from `list-style-image`)
- Bump `strict_max_version` to `147.*` and version to `4.16.1`

## Files changed

- `manifest.json` — version `4.16` → `4.16.1`, `strict_max_version` `140.*` → `147.*`
- `content/manager/accounts.js` — fix `hidden` attribute handling (3 lines)
- `content/skin/ab.css` — add `--menuitem-icon` property (2 lines)

## Test plan

- [x] Tested on Thunderbird 147.0 (Mac and Windows)
- [x] TbSync account manager displays correctly (hidden attribute fix)
- [x] Menu icons render properly (CSS fix)
- [x] EAS provider sync works end-to-end

### Servers tested

- MailSite 10.4
- Outlook.com
- Office365.com