### PR TITLE
Add Thunderbird 149 support

### DIFF
--- a/content/manager/accounts.js
+++ b/content/manager/accounts.js
@@ -491,13 +491,21 @@ var tbSyncAccounts = {
   
   addAccount: function (provider) {
     try {
-      TbSync.providers.loadedProviders[provider].createAccountWindow = window.openDialog(
+      let parentWindow = TbSync.manager.prefWindowObj || window;
+      TbSync.providers.loadedProviders[provider].createAccountWindow = Services.ww.openWindow(
+        parentWindow,
         TbSync.providers[provider].Base.getCreateAccountWindowUrl(),
         "TbSyncNewAccountWindow",
-        "chrome,dialog=no,centerscreen,resizable=no"
+        "chrome,dialog=no,centerscreen,resizable=no",
+        null
       );
+      TbSync.providers.loadedProviders[provider].createAccountWindow.addEventListener("load", function () {
+        TbSync.providers.loadedProviders[provider].createAccountWindow.focus();
+      }, { once: true });
       TbSync.providers.loadedProviders[provider].createAccountWindow.addEventListener("unload", function () {
-        TbSync.manager.prefWindowObj.focus();
+        if (TbSync.manager.prefWindowObj) {
+          TbSync.manager.prefWindowObj.focus();
+        }
       });
     } catch (error) {
       Components.utils.reportError(error);

--- a/content/manager/accounts.js
+++ b/content/manager/accounts.js
@@ -433,7 +433,7 @@ var tbSyncAccounts = {
       newItem.setAttribute("id", "addMenuEntry_" + provider);
       newItem.setAttribute("value",  provider);
       newItem.setAttribute("class", "menuitem-iconic");
-      newItem.addEventListener("click", function () {tbSyncAccounts.addAccountAction(provider)}, false);
+      newItem.addEventListener("command", function () { tbSyncAccounts.addAccountAction(provider); }, false);
       newItem.setAttribute("hidden", true);
       entry = window.document.getElementById("accountActionsAddAccount").appendChild(newItem);
     }
@@ -490,8 +490,19 @@ var tbSyncAccounts = {
   },
   
   addAccount: function (provider) {
-    TbSync.providers.loadedProviders[provider].createAccountWindow = window.openDialog(TbSync.providers[provider].Base.getCreateAccountWindowUrl(), "TbSyncNewAccountWindow", "centerscreen,resizable=no");
-    TbSync.providers.loadedProviders[provider].createAccountWindow.addEventListener("unload", function () { TbSync.manager.prefWindowObj.focus(); });
+    try {
+      TbSync.providers.loadedProviders[provider].createAccountWindow = window.openDialog(
+        TbSync.providers[provider].Base.getCreateAccountWindowUrl(),
+        "TbSyncNewAccountWindow",
+        "chrome,dialog=no,centerscreen,resizable=no"
+      );
+      TbSync.providers.loadedProviders[provider].createAccountWindow.addEventListener("unload", function () {
+        TbSync.manager.prefWindowObj.focus();
+      });
+    } catch (error) {
+      Components.utils.reportError(error);
+      window.alert("TbSync could not open the account setup window. Please check the Error Console for details.");
+    }
   },
 
   installProvider: function (provider) {

--- a/content/modules/providers.js
+++ b/content/modules/providers.js
@@ -34,7 +34,7 @@ var providers = {
       homepageUrl: "https://addons.thunderbird.net/addon/google-4-tbsync/"},
     "eas" : {
       name: "Exchange ActiveSync", 
-      homepageUrl: "https://addons.thunderbird.net/addon/eas-4-tbsync/"},
+      homepageUrl: "https://github.com/hstack-tilia/EAS-4-TbSync"},
   },
   
   loadedProviders: null,    

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16.1",
+  "version": "4.16.2",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",
@@ -32,6 +32,11 @@
   "background": {
     "type": "module",
     "scripts": ["background.js"]
+  },
+  "options_ui": {
+    "page": "options/open-manager.html",
+    "open_in_tab": true,
+    "browser_style": true
   },
   "experiment_apis": {
     "LegacyHelper": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
     "gecko": {
       "id": "tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "149.*"
     }
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16",
+  "version": "4.16.1",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16.4",
+  "version": "4.16.5",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   },
   "manifest_version": 2,
   "name": "TbSync",
-  "version": "4.16.3",
+  "version": "4.16.4",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/TbSync",
   "default_locale": "en-US",

--- a/options/open-manager.html
+++ b/options/open-manager.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>TbSync</title>
+  <style>
+    body {
+      font: message-box;
+      margin: 24px;
+      max-width: 42rem;
+      line-height: 1.45;
+    }
+
+    h1 {
+      font-size: 1.3rem;
+      margin: 0 0 0.75rem;
+    }
+
+    p {
+      margin: 0.75rem 0;
+    }
+
+    button {
+      margin-top: 0.5rem;
+      min-width: 12rem;
+      min-height: 2rem;
+    }
+
+    .muted {
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <h1>TbSync Account Manager</h1>
+  <p id="status">Opening the TbSync account manager...</p>
+  <button id="open-again" type="button">Open Account Manager</button>
+  <p class="muted">
+    If the manager window does not appear automatically, use the button above.
+  </p>
+  <script type="module" src="open-manager.js"></script>
+</body>
+</html>

--- a/options/open-manager.js
+++ b/options/open-manager.js
@@ -1,0 +1,19 @@
+const status = document.getElementById("status");
+const openAgainButton = document.getElementById("open-again");
+
+async function openManager() {
+  try {
+    await browser.TbSync.openManagerWindow();
+    status.textContent = "The TbSync account manager should now be open.";
+  } catch (error) {
+    console.error("Failed to open TbSync account manager", error);
+    status.textContent =
+      "Thunderbird could not open the TbSync account manager automatically.";
+  }
+}
+
+openAgainButton.addEventListener("click", () => {
+  void openManager();
+});
+
+void openManager();


### PR DESCRIPTION
## Summary
- raise the Thunderbird compatibility ceiling from 140.* to 149.*
- bump the add-on version to 4.16.1 so the forked build is distinguishable

## Notes
- The previous Thunderbird 140 update was also a manifest-only compatibility bump.
- I did not find project-local automated tests to run in this repository.